### PR TITLE
chore: add zizmor security scan

### DIFF
--- a/.github/workflows/publish-zenn-from-notion.yaml
+++ b/.github/workflows/publish-zenn-from-notion.yaml
@@ -11,15 +11,20 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: {}
+
 jobs:
   generate-articles:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        # zizmor: ignore[artipacked] persist-credentials is required because this job pushes generated article changes back to the repository.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
 
       - name: Install Dependencies
         run: bun install
@@ -48,35 +53,63 @@ jobs:
   create-prs:
     needs: generate-articles
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         repo:
-          - { owner: 'yoshiki-0428', name: 'zenn_repos', token: 'GH_REPO_TOKEN_YOSHIKI' }
+          - { owner: 'yoshiki-0428', name: 'zenn_repos' }
           # 必要な数だけ追加
-          - { owner: '05ryt31', name: 'zenn_repos', token: 'GH_REPO_TOKEN_RYUTO' }
+          - { owner: '05ryt31', name: 'zenn_repos' }
           # - { owner: 'owner2', name: 'repo2', token: 'TARGET_REPO2_TOKEN' }
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
-      - name: Checkout Target Repository
-        uses: actions/checkout@v4.2.2
+      - name: Checkout Target Repository (yoshiki-0428)
+        if: matrix.repo.owner == 'yoshiki-0428'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ matrix.repo.owner }}/${{ matrix.repo.name }}
-          token: ${{ secrets[matrix.repo.token] }}
+          token: ${{ secrets.GH_REPO_TOKEN_YOSHIKI }}
           path: target-repo
+          persist-credentials: false
+
+      - name: Checkout Target Repository (05ryt31)
+        if: matrix.repo.owner == '05ryt31'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ matrix.repo.owner }}/${{ matrix.repo.name }}
+          token: ${{ secrets.GH_REPO_TOKEN_RYUTO }}
+          path: target-repo
+          persist-credentials: false
 
       - name: Copy Articles into Target Repo
         run: |
           cp -r articles/${{ matrix.repo.owner }}/* target-repo/articles/
         working-directory: ${{ github.workspace }}
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+      - name: Create Pull Request (yoshiki-0428)
+        if: matrix.repo.owner == 'yoshiki-0428'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          token: ${{ secrets[matrix.repo.token] }}
+          token: ${{ secrets.GH_REPO_TOKEN_YOSHIKI }}
+          commit-message: "Update articles from Pubtech Notion"
+          branch: notion-update-${{ github.run_number }}
+          title: "Update Articles from Notion"
+          body: "Automatically generated PR with updated articles."
+          base: main
+          path: "target-repo/"
+          add-paths: "*.md"
+
+      - name: Create Pull Request (05ryt31)
+        if: matrix.repo.owner == '05ryt31'
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ secrets.GH_REPO_TOKEN_RYUTO }}
           commit-message: "Update articles from Pubtech Notion"
           branch: notion-update-${{ github.run_number }}
           title: "Update Articles from Notion"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -45,6 +45,7 @@ jobs:
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           inputs: .github/workflows/ .github/actions/
+          online-audits: false
           persona: regular
           version: v1.26.1
           advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Detect relevant changes

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,54 @@
+name: zizmor GitHub Actions Security Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Detect relevant changes
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            relevant:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+              - '.github/zizmor.yml'
+              - '.github/zizmor.yaml'
+
+      - name: Ensure action scan path exists
+        if: steps.filter.outputs.relevant == 'true'
+        run: mkdir -p .github/actions
+
+      - name: Run zizmor
+        if: steps.filter.outputs.relevant == 'true'
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          inputs: .github/workflows/ .github/actions/
+          persona: regular
+          version: v1.26.1
+          advanced-security: false
+          annotations: true
+
+      - name: No relevant changes
+        if: steps.filter.outputs.relevant != 'true'
+        run: echo "No workflow, action, or zizmor config changes. Skipping zizmor scan."


### PR DESCRIPTION
## Summary
- Add zizmor GitHub Actions security scan for `.github/workflows/` and `.github/actions/`
- Pin GitHub Actions references to commit SHAs
- Fix zizmor findings in existing workflows

## Verification
- `zizmor .`
- `git diff --check`

## Notes
- No remaining findings from `zizmor .`.
- The repository checkout in the article generation job keeps credentials with a narrow `artipacked` ignore because the job commits and pushes generated articles back to this repository.